### PR TITLE
Adding Admin on rest feathers client and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - [Passwordless Auth Example Using feathers-authentication-management](https://github.com/rhythnic/feathers-passwordless-auth-example)
 - [Feathers + Forest Admin example](https://github.com/ForestAdmin/forest-examples/tree/master/examples/feathers/sql-database) - An example for integrating Feathers with [Forest admin](https://www.forestadmin.com/).
 - [Feathers + Next.js](https://github.com/Albert-Gao/feathers-next-example)
+- [Feathers + Aor-feathers-client + Admin on Rest](https://github.com/kfern/feathers-aor-test-integration)
 
 ## Projects Using Feathers
 
@@ -307,3 +308,7 @@ Submit yours!
 ### Mithril
 
 - [feathers-mithril](https://www.npmjs.com/package/feathers-mithril) - Connect feathers.js to mithril.js (connector)
+
+### Admin on Rest
+
+- [Aor-feathers-client](https://github.com/josx/aor-feathers-client) - A feathers rest client for admin-on-rest (Admin)


### PR DESCRIPTION
Signed-off-by: José Luis Di Biase <josx@interorganic.com.ar>

### Summary

Adding the Admin on rest feathers client to the list and adding an example on how to use it.
Check https://github.com/josx/aor-feathers-client

### Other Information

Using this adaptor between feathers and admin on rest, you can easily get a admin based on feathers backend. 
- It's been used by several people
- More than 50 stars
- More than tens contributor on the project
- Several versions released.  

It think It is worth it for this list.
