### PR TITLE
Add React Admin + ra-data-feathers

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,10 @@ Submit yours!
 
 - [feathers-mithril](https://www.npmjs.com/package/feathers-mithril) - Connect feathers.js to mithril.js (connector)
 
-### Admin on Rest
+### React Admin
 
-- [Aor-feathers-client](https://github.com/josx/aor-feathers-client) - A feathers rest client for admin-on-rest (Admin)
+- [ra-data-feathers](https://github.com/josx/ra-data-feathers) - A feathers rest/socket.io client for react-admin. (Admin)
+
+### Admin on Rest (replaced by React Admin)
+
+- [Aor-feathers-client](https://github.com/josx/aor-feathers-client) - A feathers rest client for admin-on-rest. (Admin)


### PR DESCRIPTION
This commit adds ra-data-feathers and React Admin to the Frontend Frameworks list.

React Admin is the renamed version 2 of Admin on Rest. ra-data-feathers is the continuation of aor-feathers-client updated to support React Admin and renamed to fit the common naming scheme of React Admin data providers.
