### PR TITLE
Add feathers-factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@
 ### Testing
 
 - [feathers-tests-fake-app-users](https://www.npmjs.com/package/feathers-tests-fake-app-users) - Fake some feathers dependencies in service unit tests. Starter for your customized fakes (service)
+- [feathers-factory](https://github.com/JorgenVatle/feathers-factory) - Quickly build reusable random data generators for your Feathers services.
 
 ### Logging
 


### PR DESCRIPTION
Added `feathers-factory`, a small library for defining reusable random data generators for Feathers services. Very handy when you need to mock up some database entries for your tests.