### PR TITLE
Add feathers-google-maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
   - [Database](#database)
   - [Documentation](#documentation)
   - [Email and SMS](#email-and-sms)
+  - [Google](#google)
   - [Hooks](#hooks)
   - [Payments](#payments)
   - [Scaling](#scaling)
@@ -195,6 +196,10 @@
 
 - [feathers-mailer](https://github.com/feathersjs-ecosystem/feathers-mailer) - Feathers mailer service using nodemailer (service)
 - [feathers-aws-sns](https://github.com/powerkernel/feathers-aws-sns) - Feathers AWS SNS service to use with Amazon Simple Notification Service (service)
+
+### Google
+
+- [feathers-google-maps](https://github.com/DaddyWarbucks/feathers-google-maps) - Feathers service for interacting with the Google Maps API (service)
 
 ### Hooks
 


### PR DESCRIPTION
Adds `feathers-google-maps`.

I wasn't sure where this service would fit into any of the categories already defined, so I defined a new one `Google`. I noticed there were no other brand/company specific categories so I wasn't sure if that is OK? It also leaves room for other things like feathers-google-calendar, etc.